### PR TITLE
sort keys for complex IDs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.wayfair</groupId>
   <artifactId>java-froid</artifactId>
-  <version>0.1.1</version>
+  <version>0.2.0</version>
   <packaging>jar</packaging>
   <description>Java Federated Relay Object Identification</description>
   <name>java-froid</name>

--- a/src/main/java/com/wayfair/javafroid/Froid.java
+++ b/src/main/java/com/wayfair/javafroid/Froid.java
@@ -2,7 +2,9 @@ package com.wayfair.javafroid;
 
 import static com.wayfair.javafroid.ThrowingFunction.unchecked;
 
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.wayfair.javafroid.model.EntitiesResponse;
 import com.wayfair.javafroid.model.Entity;
 import com.wayfair.javafroid.model.EntityList;
@@ -49,6 +51,9 @@ public class Froid {
     this.mapper = mapper;
     this.codec = codec;
     this.documentProvider = documentProvider;
+    this.mapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+    this.mapper.enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY);
+    this.mapper.enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
   }
 
   /**
@@ -109,6 +114,7 @@ public class Froid {
               .filter(it -> !it.getKey().equals(TYPE_NAME))
               .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
+          System.out.println(mapper.writeValueAsString(data));
           byte[] encoded = codec.encode(mapper.writeValueAsBytes(data));
 
           return Entity.builder()

--- a/src/main/java/com/wayfair/javafroid/Froid.java
+++ b/src/main/java/com/wayfair/javafroid/Froid.java
@@ -2,7 +2,6 @@ package com.wayfair.javafroid;
 
 import static com.wayfair.javafroid.ThrowingFunction.unchecked;
 
-import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.wayfair.javafroid.model.EntitiesResponse;
@@ -19,6 +18,7 @@ import graphql.language.VariableReference;
 import graphql.parser.Parser;
 import graphql.relay.Relay.ResolvedGlobalId;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.HashMap;
@@ -116,7 +116,7 @@ public class Froid {
 
           return Entity.builder()
               .setTypeName(typeName)
-              .setId(toGlobalId(typeName, base64Encoder.encodeToString(encoded)))
+              .setId(toGlobalId(typeName, encoded))
               .build();
         })).collect(Collectors.toList());
 
@@ -189,9 +189,8 @@ public class Froid {
           String nodeName = field.getName();
           String nodeAlias = field.getAlias();
           String responseFieldName = (nodeAlias != null && !nodeAlias.isEmpty()) ? nodeAlias : nodeName;
-          ResolvedGlobalId globalId = fromGlobalId(idValue.get());
-          byte[] base64Decoded = base64Decoder.decode(globalId.getId());
-          byte[] froidDecoded = codec.decode(base64Decoded);
+          ResolvedGlobalId globalId = fromGlobalId(idValue.get().getBytes(StandardCharsets.UTF_8));
+          byte[] froidDecoded = codec.decode(globalId.getId().getBytes(StandardCharsets.UTF_8));
           Map data = mapper.readValue(froidDecoded, Map.class);
           data.put(TYPE_NAME, globalId.getType());
           data.put(ID, idValue.get());
@@ -210,14 +209,50 @@ public class Froid {
    * It is highly opinionated on non-padding.
    *
    * @param type the graphql type
-   * @param id   the idS
+   * @param id   the id string
    * @return the global id string
    */
-  public String toGlobalId(String type, String id) {
+  public static String toGlobalId(String type, String id) {
     return base64Encoder.encodeToString((type + ":" + id).getBytes(StandardCharsets.UTF_8));
   }
 
-  public ResolvedGlobalId fromGlobalId(String globalId) {
+  /**
+   * Re-implementing the GlobalId helpers due to incompatibility with graphql-java Relay Encoder.
+   * It is highly opinionated on non-padding.
+   *
+   * @param type the graphql type
+   * @param id   the id byte array
+   * @return the global id string
+   */
+  public static String toGlobalId(String type, byte[] id) {
+    ByteBuffer buffer = ByteBuffer.allocate(type.getBytes().length + id.length + 1);
+    buffer.put(type.getBytes(StandardCharsets.UTF_8));
+    buffer.put(":".getBytes(StandardCharsets.UTF_8));
+    buffer.put(id);
+    return base64Encoder.encodeToString(buffer.array());
+  }
+
+  /**
+   * Decode the ID value into typename and the id string.
+   *
+   * @param globalId the id String
+   * @return the Resolved typename and ID string.
+   */
+  public static ResolvedGlobalId fromGlobalId(String globalId) {
+    String[] split = new String(base64Decoder.decode(globalId), StandardCharsets.UTF_8).split(":", 2);
+    if (split.length != 2) {
+      throw new IllegalArgumentException(String.format("expecting a valid global id, got %s", globalId));
+    }
+    return new ResolvedGlobalId(split[0], split[1]);
+  }
+
+  /**
+   * Decode the ID value into typename and the id string.
+   *
+   * @param globalId the byte[]
+   * @return the Resolved typename and ID string.
+   */
+  public static ResolvedGlobalId fromGlobalId(byte[] globalId) {
     String[] split = new String(base64Decoder.decode(globalId), StandardCharsets.UTF_8).split(":", 2);
     if (split.length != 2) {
       throw new IllegalArgumentException(String.format("expecting a valid global id, got %s", globalId));

--- a/src/main/java/com/wayfair/javafroid/Froid.java
+++ b/src/main/java/com/wayfair/javafroid/Froid.java
@@ -51,8 +51,6 @@ public class Froid {
     this.mapper = mapper;
     this.codec = codec;
     this.documentProvider = documentProvider;
-    this.mapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
-    this.mapper.enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY);
     this.mapper.enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
   }
 
@@ -114,7 +112,6 @@ public class Froid {
               .filter(it -> !it.getKey().equals(TYPE_NAME))
               .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
-          System.out.println(mapper.writeValueAsString(data));
           byte[] encoded = codec.encode(mapper.writeValueAsBytes(data));
 
           return Entity.builder()

--- a/src/test/java/com/wayfair/javafroid/FroidTest.java
+++ b/src/test/java/com/wayfair/javafroid/FroidTest.java
@@ -16,7 +16,9 @@ class FroidTest {
   private static String DEMO_AUTHOR_1 = "RGVtb0F1dGhvcjpleUpoZFhSb2IzSkpaQ0k2TVgwPQ==";
   private static String DEMO_AUTHOR_4 = "RGVtb0F1dGhvcjpleUpoZFhSb2IzSkpaQ0k2TkgwPQ==";
   private static String DEMO_BOOK_1 = "RGVtb0Jvb2s6ZXlKaWIyOXJTV1FpT2pGOQ==";
+  private static String DEMO_BOOK_COMPLEX_1 = "RGVtb0Jvb2s6ZXlKd2RXSnNhWE5vWlhJaU9uc2ljSFZpYkdsemFHVnlTV1FpT2pFc0lsOWZkSGx3Wlc1aGJXVWlPaUpFWlcxdlVIVmliR2x6YUdWeUluMHNJbUp2YjJ0SlpDSTZNWDA9";
   private static String DEMO_BOOK_2 = "RGVtb0Jvb2s6ZXlKaWIyOXJTV1FpT2pKOQ==";
+  private static String DEMO_BOOK_COMPLEX_2 = "RGVtb0Jvb2s6ZXlKd2RXSnNhWE5vWlhJaU9uc2ljSFZpYkdsemFHVnlTV1FpT2pJc0lsOWZkSGx3Wlc1aGJXVWlPaUpFWlcxdlVIVmliR2x6YUdWeUluMHNJbUp2YjJ0SlpDSTZNbjA9";
 
   private Froid service = Froid.builder().build();
 
@@ -49,6 +51,51 @@ class FroidTest {
     List<String> ids = new ArrayList<String>() {{
       add(DEMO_BOOK_1);
       add(DEMO_BOOK_2);
+    }};
+
+    for (int i = 0; i < response.getData().getEntities().size(); ++i) {
+      assertEquals("DemoBook", response.getData().getEntities().get(i).getTypeName());
+      assertEquals(ids.get(i), response.getData().getEntities().get(i).getId());
+    }
+  }
+
+  @Test
+  void testEntitiesResponseComplexKey() {
+    Request request = Request
+        .builder()
+        .setQuery("query booksByGenre__node_relay_service__1($representations:[_Any!]!) {"
+            + "_entities(representations:$representations){...on DemoBook{id}}"
+            + "}")
+        .setVariables(new HashMap<String, Object>() {{
+          put("representations", new ArrayList<Object>() {{
+            add(new HashMap<String, Object>() {{
+              put("__typename", "DemoBook");
+              put("bookId", 1);
+              put("publisher", new HashMap<String, Object>() {{
+                put("__typename", "DemoPublisher");
+                put("publisherId", 1);
+              }});
+            }});
+            add(new HashMap<String, Object>() {{
+              put("__typename", "DemoBook");
+              put("bookId", 2);
+              put("publisher", new HashMap<String, Object>() {{
+                put("__typename", "DemoPublisher");
+                put("publisherId", 2);
+              }});
+            }});
+          }});
+        }})
+        .setOperationName("booksByGenre__node_relay_service__1")
+        .build();
+
+    EntitiesResponse response = (EntitiesResponse) service.handleFroidRequest(request);
+
+    assertEquals(2, response.getData().getEntities().size());
+
+    List<String> ids = new ArrayList<String>() {{
+      add(DEMO_BOOK_COMPLEX_1);
+      add(DEMO_BOOK_COMPLEX_2);
     }};
 
     for (int i = 0; i < response.getData().getEntities().size(); ++i) {

--- a/src/test/java/com/wayfair/javafroid/FroidTest.java
+++ b/src/test/java/com/wayfair/javafroid/FroidTest.java
@@ -16,9 +16,9 @@ class FroidTest {
   private static String DEMO_AUTHOR_1 = "RGVtb0F1dGhvcjpleUpoZFhSb2IzSkpaQ0k2TVgwPQ==";
   private static String DEMO_AUTHOR_4 = "RGVtb0F1dGhvcjpleUpoZFhSb2IzSkpaQ0k2TkgwPQ==";
   private static String DEMO_BOOK_1 = "RGVtb0Jvb2s6ZXlKaWIyOXJTV1FpT2pGOQ==";
-  private static String DEMO_BOOK_COMPLEX_1 = "RGVtb0Jvb2s6ZXlKd2RXSnNhWE5vWlhJaU9uc2ljSFZpYkdsemFHVnlTV1FpT2pFc0lsOWZkSGx3Wlc1aGJXVWlPaUpFWlcxdlVIVmliR2x6YUdWeUluMHNJbUp2YjJ0SlpDSTZNWDA9";
+  private static String DEMO_BOOK_COMPLEX_1 = "RGVtb0Jvb2s6ZXlKaWIyOXJTV1FpT2pFc0luQjFZbXhwYzJobGNpSTZleUpmWDNSNWNHVnVZVzFsSWpvaVJHVnRiMUIxWW14cGMyaGxjaUlzSW5CMVlteHBjMmhsY2tsa0lqb3hmWDA9";
   private static String DEMO_BOOK_2 = "RGVtb0Jvb2s6ZXlKaWIyOXJTV1FpT2pKOQ==";
-  private static String DEMO_BOOK_COMPLEX_2 = "RGVtb0Jvb2s6ZXlKd2RXSnNhWE5vWlhJaU9uc2ljSFZpYkdsemFHVnlTV1FpT2pJc0lsOWZkSGx3Wlc1aGJXVWlPaUpFWlcxdlVIVmliR2x6YUdWeUluMHNJbUp2YjJ0SlpDSTZNbjA9";
+  private static String DEMO_BOOK_COMPLEX_2 = "RGVtb0Jvb2s6ZXlKaWIyOXJTV1FpT2pJc0luQjFZbXhwYzJobGNpSTZleUpmWDNSNWNHVnVZVzFsSWpvaVJHVnRiMUIxWW14cGMyaGxjaUlzSW5CMVlteHBjMmhsY2tsa0lqb3lmWDA9";
 
   private Froid service = Froid.builder().build();
 

--- a/src/test/java/com/wayfair/javafroid/FroidTest.java
+++ b/src/test/java/com/wayfair/javafroid/FroidTest.java
@@ -97,7 +97,7 @@ class FroidTest {
         .setOperationName("booksByGenre__node_relay_service__1")
         .build();
 
-    EntitiesResponse response = (EntitiesResponse) Froid.builder().build().handleFroidRequest(request);
+    EntitiesResponse response = (EntitiesResponse) service.handleFroidRequest(request);
 
     assertEquals(1, response.getData().getEntities().size());
 
@@ -105,7 +105,64 @@ class FroidTest {
 
     assertEquals("Sorted", entity.getTypeName());
     assertEquals(
-        "U29ydGVkOnsiYSI6eyJhIjoiMSIsImIiOnsiYSI6IjEiLCJiIjoiMiIsImMiOiIzIn0sImMiOiIzIn0sImIiOiIyIiwiYyI6IjMifQ==",
+        "U29ydGVkOmV5SmhJanA3SW1FaU9pSXhJaXdpWWlJNmV5SmhJam9pTVNJc0ltSWlPaUl5SWl3aVl5STZJak1pZlN3aVl5STZJak1pZlN3aVlpSTZJaklpTENKaklqb2lNeUo5",
+        entity.getId());
+  }
+
+  @Test
+  void testEntitiesResponseComplexKeyArrays() {
+    Request request = Request
+        .builder()
+        .setQuery("query booksByGenre__node_relay_service__1($representations:[_Any!]!) {"
+            + "_entities(representations:$representations){...on Sorted{id}}"
+            + "}")
+        .setVariables(new HashMap<String, Object>() {{
+          put("representations", new ArrayList<Object>() {{
+            add(new HashMap<String, Object>() {{
+              put("__typename", "Sorted");
+              put("c", "3");
+              put("b", "2");
+              put("a", new HashMap<String, Object>() {{
+                put("c", "3");
+                put("a", "1");
+                put("b", new HashMap<String, Object>() {{
+                  put("b", "2");
+                  put("a", "1");
+                  put("c", "3");
+                }});
+              }});
+              put("d", new ArrayList<Object>() {{
+                  add("z");
+                  add("1");
+                  add(new HashMap<String, Object>() {{
+                    put("b", "2");
+                    put("d", "4");
+                    put("a", "1");
+                  }});
+                  add(new HashMap<String, Object>() {{
+                    put("b", new ArrayList<Object>(){{
+                      add(new HashMap<String, Object>() {{
+                        put("c", "3");
+                        put("b", "2");
+                      }});
+                    }});
+                  }});
+                  add(new ArrayList<Object>(){{}});
+              }});
+            }});
+          }});
+        }})
+        .setOperationName("booksByGenre__node_relay_service__1")
+        .build();
+    EntitiesResponse response = (EntitiesResponse) service.handleFroidRequest(request);
+
+    assertEquals(1, response.getData().getEntities().size());
+
+    Entity entity = response.getData().getEntities().get(0);
+
+    assertEquals("Sorted", entity.getTypeName());
+    assertEquals(
+        "U29ydGVkOmV5SmhJanA3SW1FaU9pSXhJaXdpWWlJNmV5SmhJam9pTVNJc0ltSWlPaUl5SWl3aVl5STZJak1pZlN3aVl5STZJak1pZlN3aVlpSTZJaklpTENKaklqb2lNeUlzSW1RaU9sc2llaUlzSWpFaUxIc2lZU0k2SWpFaUxDSmlJam9pTWlJc0ltUWlPaUkwSW4wc2V5SmlJanBiZXlKaUlqb2lNaUlzSW1NaU9pSXpJbjFkZlN4YlhWMTk=",
         entity.getId());
   }
 


### PR DESCRIPTION
## Description

- additional unit test for IDs comprised of entities with complex object structures.
- sort entity keys for complex IDs
- remove base64 encoding within core FROID algorithms. Users must add this to their Codec implementation.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [x] Breaking Change
- [x] Refactor
- [ ] Documentation
- [x] Other (please describe)

## Checklist

- [x] I have read the
      [contributing guidelines](https://github.com/wayfair-incubator/java-froid/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
